### PR TITLE
Enables gradle support for Android Studio and sonatype/maven push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Eclipse
 *.class
 Branch-SDK-TestBed/.settings/org.eclipse.jdt.core.prefs
 Branch-SDK/.settings/org.eclipse.jdt.core.prefs
@@ -5,3 +6,13 @@ Branch-SDK/gen/
 Branch-SDK/bin/
 Branch-SDK-TestBed/gen/
 Branch-SDK-TestBed/bin/
+
+# Android Studio
+.idea
+*.iml
+local.properties
+Branch-SDK/build/
+Branch-SDK-TestBed/build/
+
+# Gradle
+.gradle/*

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ Branch-SDK/build/
 Branch-SDK-TestBed/build/
 
 # Gradle
+build/*
 .gradle/*

--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')

--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -3,12 +3,28 @@ apply plugin: 'com.android.application'
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(':Branch-SDK')
+    
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+    
+    defaultConfig {
+        minSdkVersion 7
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        versionName project.VERSION_NAME
+        versionCode Integer.parseInt(project.VERSION_CODE)
+    }
 
+    signingConfigs { release }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
+    
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -32,4 +48,22 @@ android {
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
     }
+}
+
+File propFile = file('signing.properties');
+if (propFile.exists()) {
+    def Properties props = new Properties()
+    props.load(new FileInputStream(propFile))
+
+    if (props.containsKey('STORE_FILE') && props.containsKey('STORE_PASSWORD') &&
+            props.containsKey('KEY_ALIAS') && props.containsKey('KEY_PASSWORD')) {
+        android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+        android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
+        android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+        android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
+    } else {
+        android.buildTypes.release.signingConfig = null
+    }
+} else {
+        android.buildTypes.release.signingConfig = null
 }

--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     sourceSets {
         main {

--- a/Branch-SDK-TestBed/signing.properties.sample
+++ b/Branch-SDK-TestBed/signing.properties.sample
@@ -1,0 +1,4 @@
+STORE_FILE=/path/to/your.keystore
+STORE_PASSWORD=yourkeystorepass
+KEY_ALIAS=projectkeyalias
+KEY_PASSWORD=keyaliaspassword

--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -32,3 +32,5 @@ android {
         release.setRoot('build-types/release')
     }
 }
+
+apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     sourceSets {
         main {

--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -5,8 +5,15 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+    
+    defaultConfig {
+        minSdkVersion 7
+        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        versionName project.VERSION_NAME
+        versionCode Integer.parseInt(project.VERSION_CODE)
+    }
 
     sourceSets {
         main {

--- a/Branch-SDK/gradle.properties
+++ b/Branch-SDK/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=Branch Android SDK
+POM_ARTIFACT_ID=library
+POM_PACKAGING=aar

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.+'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,3 +7,12 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.+'
     }
 }
+
+allprojects {
+    version = VERSION_NAME
+    group = GROUP
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,18 @@
+VERSION_NAME=1.1.8
+VERSION_CODE=1
+GROUP=io.branch.sdk.android
+
+POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.
+POM_URL=https://github.com/BranchMetrics/Branch-Android-SDK/
+POM_SCM_URL=https://github.com/BranchMetrics/Branch-Android-SDK/
+POM_SCM_CONNECTION=scm:git@github.com:BranchMetrics/Branch-Android-SDK.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:BranchMetrics/Branch-Android-SDK.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=qinwei
+POM_DEVELOPER_NAME=Qinwei Gong
+
+ANDROID_BUILD_TARGET_SDK_VERSION=19
+ANDROID_BUILD_TOOLS_VERSION=21.1.2
+ANDROID_BUILD_SDK_VERSION=21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Jan 21 23:21:35 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
This will update the gradle definitions to comply with the currently supported versions. To add Branch-Android-SDK in android studio:

- Close your current project if any
- Import from Non-Android-Studio Project
- Select build.gradle in the root
- Wait
- Press: sync gradle build

The project should display as 2 modules automagically. You might want to consider changing from an Eclipse directory structure to the Android Studio directory studio as well.