### PR TITLE
Deprecation annotation and tag

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -407,8 +407,10 @@ public class Branch {
 	 * @return			An initialised {@link Branch} object, either fetched from a pre-initialised 
 	 * 					instance within the singleton class, or a newly instantiated object where 
 	 * 					one was not already requested during the current app lifecycle.
-	 * 
+	 *
+	 * @deprecated 		Use deprecated {@link #getInstance(Context)}
 	 */
+	@Deprecated
 	public static Branch getInstance(Context context, String branchKey) {
 		if (branchReferral_ == null) {
 			branchReferral_ = Branch.initInstance(context);


### PR DESCRIPTION
A deprecated token such as this function should be annotated with the `java.lang.Deprecated` annotation so that compiler warnings may arise and IDE's such as Android Studio may highlight it as such.

The oracle and google spec dictate that additionally a token should be tagged in the javadoc with a reference to the replacement, if any.