### PR TITLE
Hotfix/string equals

### DIFF
--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -227,7 +227,8 @@ public class SystemObserver {
 				if ((appInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 1) {
 					JSONObject packObj = new JSONObject();
 					try {
-						String label = appInfo.loadLabel(pm).toString();
+						CharSequence labelCs = appInfo.loadLabel(pm);
+						String label = labelCs == null ? null : labelCs.toString();
 						if (label != null)
 							packObj.put("name", label);
 						String packName = appInfo.packageName;

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -533,7 +533,7 @@ public class SystemObserver {
 	public int getUpdateState(boolean updatePrefs) {
 		PrefHelper pHelper = PrefHelper.getInstance(context_);
 		String currAppVersion = getAppVersion(); 
-		if (pHelper.getAppVersion() == PrefHelper.NO_STRING_VALUE) {
+		if (PrefHelper.NO_STRING_VALUE.equals(pHelper.getAppVersion())) {
 			// if no app version is in storage, this must be the first time Branch is here
 			if (updatePrefs) {
 				pHelper.setAppVersion(currAppVersion);


### PR DESCRIPTION
Two edits: one was prone for a bug and the other one was a redundant check that always resolved to true. Commit messages hold more information.