### PR TITLE
Don't leak the longPress listener

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -313,7 +313,6 @@ public class Branch {
 	private SparseArray<String> debugListenerInitHistory_;
 	private OnTouchListener debugOnTouchListener_;
 	private Handler debugHandler_;
-	private Runnable longPressed_;
 	private boolean debugStarted_;
 
 	private Map<BranchLinkData, String> linkCache_;
@@ -3864,6 +3863,7 @@ public class Branch {
 	}
 	
 	public class BranchWindowCallback implements Window.Callback {
+		private Runnable longPressed_;
 		private Window.Callback callback_;
 		
 		public BranchWindowCallback(Window.Callback callback) {


### PR DESCRIPTION
Sorry, one more.

At a high level, I don't think `BranchWindowCallback` should be hooked up at all unless BuildConfig.DEBUG is true.  IMO it's crazy to ship something that overrides touch events at this high of a level.  

For now I'm just removing Branch from my app due to these issues.  The `Branch` class needs some _serious_ refactoring to avoid bogging down apps with memory leaks.