### PR TITLE
Installs should override all opens

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -286,8 +286,6 @@ public class ServerRequestQueue {
                         || req.getTag().equals(BranchRemoteInterface.REQ_TAG_REGISTER_OPEN))) {
                     if (req.getTag().equals(BranchRemoteInterface.REQ_TAG_REGISTER_INSTALL)) {
 						tag = BranchRemoteInterface.REQ_TAG_REGISTER_INSTALL;
-					} else {
-						tag = BranchRemoteInterface.REQ_TAG_REGISTER_OPEN;
 					}
 					iter.remove();
 					break;


### PR DESCRIPTION
When creating a new `Branch` instance, regardless of auto sessions or not, it will create a new `ServerRequestQueue` which in turn calls `ServerRequestQueue#retrieve`.

If there, for any reason, is an `open` request in the retrieved storage, it will bump any later `install` request (because of missing user information). Since the install will always be trumped by the earlier open, no request will ever return, callbacks not called and users not initialized or installed.

This fixed #92 and #94 and should be incorperated in #76 .

Further more, from this analysis we can see that `setIdentity` requests should also be overwritten. We only care about the newest call, not earlier ones.